### PR TITLE
Support for Maven, equivalence of building tools update for kilim 0.7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+target/**
+classes-*/**
+testclasses-*/**
 classes/**/*
 testclasses/**/*
 .DS_Store

--- a/build-equiv.sh
+++ b/build-equiv.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+echo Cleaning
+rm -rf testclasses-* classes-* testclasses classes
+echo Build via Ant
+ant clean compile
+mv classes classes-ant
+mv testclasses testclasses-ant
+echo Build via shell script
+./build.sh
+mv classes classes-sh
+mv testclasses testclasses-sh
+echo Build via Maven
+mvn install
+mv classes classes-mvn
+mv testclasses testclasses-mvn
+echo Comparing
+diff -aqr classes-mvn/ classes-sh/ && echo success
+diff -aqr testclasses-mvn/ testclasses-sh/ && echo success
+diff -aqr classes-ant/ classes-sh/ && echo success
+diff -aqr testclasses-ant/ testclasses-sh/ && echo success

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,48 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.7.1</version>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-weaver</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>kilim/test/AllNotWoven.java</include>
+							</includes>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-api</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<testClassesDirectory>${basedir}/testclasses</testClassesDirectory>
+							<classpathDependencyScopeExclude>runtime</classpathDependencyScopeExclude>
+							<systemPropertyVariables>
+								<kilim.Scheduler.numThreads>10</kilim.Scheduler.numThreads>
+							</systemPropertyVariables>
+							<includes>
+								<include>kilim/test/AllWoven.java</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>kilim</groupId>
+	<artifactId>kilim</artifactId>
+	<version>0.7.2</version>
+	<packaging>jar</packaging>
+
+	<properties>
+		<jdk.version>1.6</jdk.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>asm</groupId>
+			<artifactId>asm-all</artifactId>
+			<version>2.2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.2</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<sourceDirectory>src/</sourceDirectory>
+		<testSourceDirectory>test/</testSourceDirectory>
+		<outputDirectory>classes/</outputDirectory>
+		<testOutputDirectory>classes/</testOutputDirectory>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${basedir}/bench</source>
+								<source>${basedir}/examples</source>
+								<source>${basedir}/bench</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>2.4.1</version>
+				<executions>
+					<execution>
+						<id>auto-clean</id>
+						<phase>initialize</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+				<!--<configuration> <filesets> <fileset> <directory>.</directory> <includes> 
+					<include>${project.build.outputDirectory}</include> <include>${project.build.testOutputDirectory}</include> 
+					</includes> </fileset> </filesets> </configuration> -->
+			</plugin><!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-javadoc-plugin</artifactId> 
+				<executions> <execution> <id>attach-javadocs</id> <goals> <goal>jar</goal> 
+				</goals> </execution> </executions> </plugin> <plugin> <groupId>org.apache.maven.plugins</groupId> 
+				<artifactId>maven-source-plugin</artifactId> <executions> <execution> <id>attach-sources</id> 
+				<goals> <goal>jar</goal> </goals> </execution> </executions> </plugin> -->
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<debug>true</debug>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- java -ea kilim.tools.Asm -d ./classes `find . -name "*.j"` -->
+						<id>kilim-asm</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>java</executable>
+							<arguments>
+								<argument>-classpath</argument>
+								<classpath />
+								<argument>-ea</argument>
+								<argument>kilim.tools.Asm</argument>
+								<argument>-d</argument>
+								<argument>${project.build.outputDirectory}</argument>
+								<argument>${project.build.testSourceDirectory}/kilim/test/ex/ExJSR.j</argument>
+								<argument>${project.build.testSourceDirectory}/kilim/test/ex/ExYieldSub.j</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<!-- java -ea kilim.tools.Weaver -d ./classes -x "ExInvalid|test" ./classes -->
+						<id>kilim-weave-main</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>java</executable>
+							<classpathScope>test</classpathScope>
+							<arguments>
+								<argument>-classpath</argument>
+								<classpath />
+								<argument>-ea</argument>
+								<argument>kilim.tools.Weaver</argument>
+								<argument>-d</argument>
+								<argument>${project.build.outputDirectory}</argument>
+								<argument>-x</argument>
+								<argument>ExInvalid|test</argument>
+								<argument>${project.build.outputDirectory}</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<!-- java -ea kilim.tools.Weaver -d ./testclasses -x "ExInvalid" ./classes -->
+						<id>kilim-weave-test</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>java</executable>
+							<classpathScope>test</classpathScope>
+							<arguments>
+								<argument>-classpath</argument>
+								<classpath />
+								<argument>-ea</argument>
+								<argument>kilim.tools.Weaver</argument>
+								<argument>-d</argument>
+								<argument>${basedir}/testclasses</argument>
+								<argument>-x</argument>
+								<argument>ExInvalid</argument>
+								<argument>${project.build.OutputDirectory}</argument>
+							</arguments>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>kilim</groupId>
 	<artifactId>kilim</artifactId>
-	<version>0.7.2</version>
+	<version>0.7.3</version>
 	<packaging>jar</packaging>
 
 	<properties>
@@ -37,6 +37,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.5</version>
 				<executions>
 					<execution>
 						<id>add-source</id>
@@ -76,6 +77,7 @@
 				<goals> <goal>jar</goal> </goals> </execution> </executions> </plugin> -->
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
 				<configuration>
 					<debug>true</debug>
 					<source>${jdk.version}</source>
@@ -85,6 +87,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.2.1</version>
 				<executions>
 					<execution>
 						<!-- java -ea kilim.tools.Asm -d ./classes `find . -name "*.j"` -->


### PR DESCRIPTION
This pull request is the same as https://github.com/kilim/kilim/pull/7 except I rebased to kilim 0.7.3 and fixed some maven 3.0 warnings.

I also was able to add weave step after compile directly into maven with:

	<build>
		<plugins>
			<plugin>
				<groupId>org.codehaus.mojo</groupId>
				<artifactId>exec-maven-plugin</artifactId>
				<version>1.2.1</version>
				<executions>
					<execution>
						<id>weave test classes</id>
						<phase>process-classes</phase>
						<goals>
							<goal>exec</goal>
						</goals>
						<configuration>
							<executable>java</executable>
							<arguments>
								<argument>-classpath</argument>
								<classpath />
								<argument>kilim.tools.Weaver</argument>
								<argument>${project.build.outputDirectory}</argument>
								<argument>-d</argument>
								<argument>${project.build.outputDirectory}</argument>
							</arguments>
						</configuration>
					</execution>
				</executions>
			</plugin>
		</plugins>
	</build>
