### PR TITLE
add classloader support to classweaver

### DIFF
--- a/src/kilim/analysis/ClassWeaver.java
+++ b/src/kilim/analysis/ClassWeaver.java
@@ -79,7 +79,7 @@ public class ClassWeaver {
         classFlow.analyze(false);
         if (needsWeaving() && classFlow.isPausable()) {
             boolean computeFrames = (classFlow.version & 0x00FF) >= 50;
-            ClassWriter cw = new kilim.asm.ClassWriter(computeFrames ? ClassWriter.COMPUTE_FRAMES : 0, classLoader);
+            ClassWriter cw = new kilim.analysis.ClassWriter(computeFrames ? ClassWriter.COMPUTE_FRAMES : 0, classLoader);
             accept(cw);
             addClassInfo(new ClassInfo(classFlow.getClassName(), cw.toByteArray()));
         }
@@ -219,7 +219,7 @@ public class ClassWeaver {
         synchronized (stateClasses) {
             classInfo= stateClasses.get(className);
             if (classInfo == null) {
-                ClassWriter cw = new kilim.asm.ClassWriter(ClassWriter.COMPUTE_FRAMES, classLoader);
+                ClassWriter cw = new kilim.analysis.ClassWriter(ClassWriter.COMPUTE_FRAMES, classLoader);
                 cw.visit(V1_1, ACC_PUBLIC | ACC_FINAL, className, null, "kilim/State", null);
 
                 // Create default constructor

--- a/src/kilim/analysis/ClassWriter.java
+++ b/src/kilim/analysis/ClassWriter.java
@@ -1,4 +1,4 @@
-package kilim.asm;
+package kilim.analysis;
 
 public class ClassWriter extends org.objectweb.asm.ClassWriter {
 	private final ClassLoader classLoader;


### PR DESCRIPTION
My project does a lot of java code generation that is then weaved by the weaver. This is all done in memory, no file system interaction at all. We directly use the ClassWeaver rather than Tools/Weaver. We also utilise a custom classloader to provide dynamic resolution of dependencies that might have also been generated previously.

With the updates to use asm 4.1 our code stopped working. I managed to get everything working again by adding support for classloader in asm ClassWriter.

I got this exact error in my code when upgrading to the stackmap branch of kilim.

http://stackoverflow.com/questions/11292701/error-while-instrumenting-class-files-asm-classwriter-getcommonsuperclass
