### PR TITLE
Assigning random available port in IO/HTTP unit tests

### DIFF
--- a/src/kilim/nio/NioSelectorScheduler.java
+++ b/src/kilim/nio/NioSelectorScheduler.java
@@ -71,11 +71,12 @@ public class NioSelectorScheduler extends Scheduler {
         t.start();
     }
 
-    public void listen(int port, Class<? extends SessionTask> sockTaskClass, Scheduler sockTaskScheduler)
+    public int listen(int port, Class<? extends SessionTask> sockTaskClass, Scheduler sockTaskScheduler)
             throws IOException {
-        Task t = new ListenTask(port, this, sockTaskClass);
+        ListenTask t = new ListenTask(port, this, sockTaskClass);
         t.setScheduler(this);
         t.start();
+        return t.port(); 
     }
 
     @Override
@@ -201,7 +202,16 @@ public class NioSelectorScheduler extends Scheduler {
             ssc.socket().bind(new InetSocketAddress(port), LISTEN_BACKLOG); //
             ssc.configureBlocking(false);
             setEndPoint(new EndPoint(selScheduler.registrationMbx, ssc));
+        
+            // if port is automatically assigned then retrieve actual value
+            if(port == 0) {
+                this.port = ssc.socket().getLocalPort();
+            };    
         }
+
+        public int port() {
+            return this.port;
+        }    
 
         public String toString() {
             return "ListenTask: " + port;

--- a/test/kilim/test/TestHTTP.java
+++ b/test/kilim/test/TestHTTP.java
@@ -26,15 +26,16 @@ import kilim.http.HttpSession;
 import kilim.nio.NioSelectorScheduler;
 
 public class TestHTTP extends TestCase {
-    static int PORT = 9797;
     static final int ITERS = 10;
     static final int NCLIENTS = 100;
+
     NioSelectorScheduler nio;
+    int port;
     
     @Override
     protected void setUp() throws Exception {
         nio = new NioSelectorScheduler(); // Starts a single thread that manages the select loop
-        nio.listen(PORT, TestHttpServer.class, Scheduler.getDefaultScheduler()); //
+        port = nio.listen(0, TestHttpServer.class, Scheduler.getDefaultScheduler()); //
         Thread.sleep(50); // Allow the socket to be registered and opened.
     }
     
@@ -42,12 +43,11 @@ public class TestHTTP extends TestCase {
     protected void tearDown() throws Exception {
         nio.shutdown();
         Scheduler.getDefaultScheduler().shutdown();
-        PORT++; // start the next test with a new socket.
     }
     
     public void testReqResp() throws IOException {
         String path = "/hello";
-        URL url = new URL("http://localhost:" + PORT + path);
+        URL url = new URL("http://localhost:" + port + path);
         URLConnection conn = url.openConnection();
         conn.setDefaultUseCaches(false);
         BufferedReader in = new BufferedReader(
@@ -60,7 +60,7 @@ public class TestHTTP extends TestCase {
     
     public void testQuery() throws IOException {
         String path = "/%7ekilim/home.html?info?code=200&desc=Rolls%20Royce";
-        URL url = new URL("http://localhost:" + PORT + path);
+        URL url = new URL("http://localhost:" + port + path);
         HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         conn.setDefaultUseCaches(false);
         BufferedReader in = new BufferedReader(
@@ -75,7 +75,7 @@ public class TestHTTP extends TestCase {
     
     public void testChunking() throws IOException {
         String path = "/%7ekilim/home.html?buy?code=200&desc=Rolls%20Royce";
-        URL url = new URL("http://localhost:" + PORT + path);
+        URL url = new URL("http://localhost:" + port + path);
         HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         conn.setDefaultUseCaches(false);
         conn.setDoOutput(true);

--- a/test/kilim/test/TestIO.java
+++ b/test/kilim/test/TestIO.java
@@ -23,15 +23,15 @@ import kilim.nio.NioSelectorScheduler;
 import kilim.nio.SessionTask;
 
 public class TestIO extends TestCase {
-    static final int PORT = 9797;
     static final int ITERS = 10;
     static final int NCLIENTS = 100;
     NioSelectorScheduler nio;
+    int port;
     
     @Override
     protected void setUp() throws Exception {
         nio = new NioSelectorScheduler(); // Starts a single thread that manages the select loop
-        nio.listen(PORT, EchoServer.class, Scheduler.getDefaultScheduler()); //
+        port = nio.listen(0, EchoServer.class, Scheduler.getDefaultScheduler()); //
     }
     
     @Override
@@ -47,7 +47,7 @@ public class TestIO extends TestCase {
     public void testParallelEchoes() throws IOException {
         try {
             for (int i = 0; i < NCLIENTS; i++) {
-                client();
+                client(port);
             }
         } catch (IOException e) {
             e.printStackTrace();
@@ -59,7 +59,7 @@ public class TestIO extends TestCase {
         SocketChannel sc = SocketChannel.open();
         
         try {
-            sc.socket().connect(new InetSocketAddress("localhost", PORT));
+            sc.socket().connect(new InetSocketAddress("localhost", port));
             String s = "Iteration #0. DONE"; // Only because EchoServer checks for it. 
             byte[] sbytes = s.getBytes();
             ByteArrayOutputStream baos = new ByteArrayOutputStream(100);
@@ -126,11 +126,11 @@ public class TestIO extends TestCase {
     }
     
     
-    static void client() throws IOException {
+    static void client(int port) throws IOException {
         SocketChannel sc = SocketChannel.open();
         try {
             // Client using regular JDK I/O API. 
-            sc.socket().connect(new InetSocketAddress("localhost", PORT));
+            sc.socket().connect(new InetSocketAddress("localhost", port));
             for (int i = 0 ; i < ITERS; i++) {
                 String s = "Iteration #" + i;
                 if (i == ITERS-1) {s += " DONE";}


### PR DESCRIPTION
Unit tests fail if port specified in their implementation is taken. The solution is to use 0 as port value when creating socket - it will assign first available port in high range. 

Added ListenTask::port() method to retrieve actual port and exposed port number in NioSelectorScheduler::listen(). Changed unit tests to use randomly allocated port.
