### PR TITLE
Use relative paths for exclusion matching in weaver.

### DIFF
--- a/src/kilim/analysis/FileLister.java
+++ b/src/kilim/analysis/FileLister.java
@@ -104,10 +104,7 @@ class DirIterator extends FileContainer {
         }
         @Override
         public String getFileName() {
-            try {
-                return file.getCanonicalPath();
-            } catch (IOException ignore) {}
-            return null;
+            return file.getPath();
         }
 
         @Override


### PR DESCRIPTION
Hi, I've run into a problem while building kilim from source. The weaver would not process any of the classes after they have been compiled, specifically this line in `build.sh` didn't work:

```
java -ea kilim.tools.Weaver -d ./classes -x "ExInvalid|test" ./classes
```

It turns out that the problem was that the regular expression of the exclusion filter was matched agains the absolute path of each `.class` file. And because I checked out the repository into a folder called `kilim-test`, all files would be excluded by the filter.

I've fixed it by modifying  `DirIterator.getFileName()` so that the paths it returns are no longer absolute but relative to the directory specified on the command line.
